### PR TITLE
Add user story 11

### DIFF
--- a/app/controllers/palettes_controller.rb
+++ b/app/controllers/palettes_controller.rb
@@ -1,9 +1,25 @@
 class PalettesController < ApplicationController
+  
+  def new
+  end
+
   def index
     @palettes = Palette.all.order("created_at DESC")
   end
 
   def show
     @palette = Palette.find(params[:id])
+  end
+
+  def create
+    Palette.create(palette_params)
+    redirect_to '/palettes'
+  end
+  
+
+  private
+
+  def palette_params
+    params.permit(:name, :brand, :cartridge_capacity, :recyclable)
   end
 end

--- a/app/views/palettes/index.html.erb
+++ b/app/views/palettes/index.html.erb
@@ -1,5 +1,7 @@
 <h1>Palettes</h1>
 
+<%= link_to 'New Palette', '/palettes/new' %>
+
 <% @palettes.each do |palette| %>
 
   <h3><%= palette.name %></h3>

--- a/app/views/palettes/new.html.erb
+++ b/app/views/palettes/new.html.erb
@@ -1,0 +1,15 @@
+<%= form_with url: "/palettes", method: :post, local: true do |form| %>
+  <p><%= form.label :name, "Palette Name: " %></p>
+  <p><%= form.text_field :name %></p>
+  <br>
+  <p><%= form.label :brand, "Palette Brand: "  %></p>
+  <p><%= form.text_field :brand %></p>
+  <br>
+  <p><%= form.label :cartridge_capacity, "Palette Cartridge Capacity: "  %></p>
+  <p><%= form.text_field :cartridge_capacity %></p>
+  <br>
+  <p><%= form.label :recyclable, "Recyclable?: "  %></p>
+  <p><%= form.text_field :recyclable %></p>
+  
+  <p><%= form.submit 'Create Palette' %></p>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,10 +2,12 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
   get '/palettes', to: 'palettes#index'
+  get '/palettes/new', to: 'palettes#new'
   get '/palettes/:id', to: 'palettes#show'
 
   get '/paints', to: 'paints#index'
   get '/paints/:id', to: 'paints#show'
 
   get '/palettes/:id/paints', to: 'palette_paints#index'
+  post '/palettes', to: 'palettes#create'
 end

--- a/spec/features/palettes/new_spec.rb
+++ b/spec/features/palettes/new_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe 'New Palette' do
+  describe 'As a visitor' do
+    describe 'When I visit the new Palette form by clicking a link on the index' do
+      it 'I can create a new palette' do
+        visit '/palettes'
+
+        click_link('New Palette')
+
+        expect(current_path).to eq('/palettes/new')
+
+      end
+
+      it 'after creating palette, redirected to palette index with new record shown' do
+        visit '/palettes/new'
+
+        fill_in 'Name', with: "Mixed-media Travel Tin"
+        fill_in 'Brand', with: "Qor"
+        fill_in 'Cartridge Capacity', with: 12
+        fill_in 'Recyclable', with: true
+
+        click_button "Create Palette"
+
+        expect(current_path).to eq("/palettes")
+        expect(page).to have_content("Mixed-media Travel Tin")
+      end
+    end
+  end
+end


### PR DESCRIPTION
User Story 11, Parent Creation 

As a visitor
When I visit the Parent Index page
Then I see a link to create a new Parent record, "New Parent"
When I click this link
Then I am taken to '/parents/new' where I  see a form for a new parent record
When I fill out the form with a new parent's attributes:
And I click the button "Create Parent" to submit the form
Then a `POST` request is sent to the '/parents' route,
a new parent record is created,
and I am redirected to the Parent Index page where I see the new Parent displayed.