### PR TITLE
13 user story

### DIFF
--- a/app/controllers/palette_paints_controller.rb
+++ b/app/controllers/palette_paints_controller.rb
@@ -3,4 +3,20 @@ class PalettePaintsController < ApplicationController
     @palette = Palette.find(params[:id])
     @paints = @palette.paints
   end
+
+  def new
+    @palette = Palette.find(params[:id])
+  end
+
+  def create
+    palette = Palette.find(params[:id])
+    paint = palette.paints.create!(paint_params)
+
+    redirect_to "/palettes/#{palette.id}/paints"
+  end
+
+  private
+  def paint_params
+    params.permit(:paint_name, :medium, :series, :opaque)
+  end
 end

--- a/app/views/palette_paints/index.html.erb
+++ b/app/views/palette_paints/index.html.erb
@@ -1,5 +1,7 @@
 <h1><%= @palette.name %></h1>
 
+<%= link_to 'New Paint', "/palettes/#{@palette.id}/paints/new" %>
+
 <% @paints.each do |paint| %>
   <h3>Paint Name: <%= paint.paint_name %></h3>
   <p>Medium: <%= paint.medium%></p>

--- a/app/views/palette_paints/new.html.erb
+++ b/app/views/palette_paints/new.html.erb
@@ -1,0 +1,15 @@
+<%= form_with url: "/palettes/#{@palette.id}/paints/new", method: :post, local: true do |form| %>
+  <p><%= form.label :paint_name, "Paint Name: " %></p>
+  <p><%= form.text_field :paint_name %></p>
+  <br>
+  <p><%= form.label :brand, "Medium: "  %></p>
+  <p><%= form.text_field :brand %></p>
+  <br>
+  <p><%= form.label :series, "Series: "  %></p>
+  <p><%= form.text_field :series %></p>
+  <br>
+  <p><%= form.label :opaque, "Opaque?: "  %></p>
+  <p><%= form.text_field :opaque %></p>
+  
+  <p><%= form.submit 'Create Paint' %></p>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,4 +13,7 @@ Rails.application.routes.draw do
 
   get 'palettes/:id/edit', to: 'palettes#edit'
   patch '/palettes/:id', to: 'palettes#update'
+
+  get '/palettes/:id/paints/new', to: 'palette_paints#new'
+  post '/palettes/:id/paints/new', to: 'palette_paints#create'
 end

--- a/spec/features/palette_paints/index_spec.rb
+++ b/spec/features/palette_paints/index_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe 'Palettes index page' do
+  before do
+    Palette.destroy_all
+    Paint.destroy_all
+  end
+
+  let!(:palette) { Palette.create!(name: "Professional Watercolor", brand: "Windsor & Newton", cartridge_capacity: 24, recyclable: true) }
+  let!(:palette_2) { Palette.create!(name: "Professional Goache", brand: "Windsor & Newton", cartridge_capacity: 12, recyclable: false) }
+
+  let!(:paint) { Paint.create!(paint_name: "Alizarin Crimson", medium: "Watercolor", series: 1, opaque: false, palette_id: palette.id) }
+  let!(:paint_2) { Paint.create(paint_name: "French Ultramarine", medium: "Watercolor", series: 2, opaque: false, palette_id: palette.id) }
+  let!(:paint_3) { Paint.create(paint_name: "Permanent Sap Green", medium: "Watercolor", series: 1, opaque: false, palette_id: palette.id) }
+  let!(:paint_4) { Paint.create(paint_name: "Orange Lake Deep", medium: "Gouache", series: 1, opaque: true, palette_id: palette_2.id) }
+  let!(:paint_5) { Paint.create(paint_name: "Oxide of Chromium", medium: "Gouache", series: 2, opaque: false, palette_id: palette_2.id) }
+
+  it 'displays all palette paints and their attributes' do
+    visit "/palettes/#{palette.id}/paints"
+
+    expect(page).to have_content(paint.paint_name)
+    expect(page).to have_content(paint.medium)
+    expect(page).to have_content(paint.series)
+    expect(page).to have_content(paint.opaque)
+    expect(page).to have_content(paint.palette_id)
+
+    expect(page).to have_content(paint_2.paint_name)
+    expect(page).to have_content(paint_2.medium)
+    expect(page).to have_content(paint_2.series)
+    expect(page).to have_content(paint_2.opaque)
+    expect(page).to have_content(paint_2.palette_id)
+
+    expect(page).to have_content(paint_3.paint_name)
+    expect(page).to have_content(paint_3.medium)
+    expect(page).to have_content(paint_3.series)
+    expect(page).to have_content(paint_3.opaque)
+    expect(page).to have_content(paint_3.palette_id)
+  end
+end

--- a/spec/features/palette_paints/new_spec.rb
+++ b/spec/features/palette_paints/new_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe 'New Palette Paint' do
+
+  let!(:palette) { Palette.create!(name: "Professional Watercolor", brand: "Windsor & Newton", cartridge_capacity: 24, recyclable: true) }
+  let!(:palette_2) { Palette.create!(name: "Professional Goache", brand: "Windsor & Newton", cartridge_capacity: 12, recyclable: false) }
+
+  describe 'user story 13' do
+    describe 'When I visit a Palette paints Index page' do
+      it 'I see a link to add a new paint for that palette that leads to a form page' do
+        visit "/palettes/#{palette.id}/paints"
+        
+        click_link('New Paint')
+
+        expect(current_path).to eq("/palettes/#{palette.id}/paints/new")
+      end
+
+      it 'when I submit form, I am redirected to palette_paint index with new paint listed' do
+        visit "/palettes/#{palette.id}/paints/new"
+
+        fill_in 'Paint Name', with: 'Antwerp Blue'
+        fill_in 'Medium', with: 'Watercolor'
+        fill_in 'Series', with: 1
+        fill_in 'Opaque', with: false
+
+        click_button 'Create Paint'
+
+        expect(current_path).to eq("/palettes/#{palette.id}/paints")
+        expect(page).to have_content("Antwerp Blue")
+        expect(page).to have_content("Watercolor")
+        expect(page).to have_content(1)
+        expect(page).to have_content('false')
+      end
+    end
+  end
+end


### PR DESCRIPTION
User Story 13, Parent Child Creation 

As a visitor
When I visit a Parent Children Index page
Then I see a link to add a new adoptable child for that parent "Create Child"
When I click the link
I am taken to '/parents/:parent_id/child_table_name/new' where I see a form to add a new adoptable child
When I fill in the form with the child's attributes:
And I click the button "Create Child"
Then a `POST` request is sent to '/parents/:parent_id/child_table_name',
a new child object/row is created for that parent,
and I am redirected to the Parent Childs Index page where I can see the new child listed