### PR TITLE
Add User Story 17

### DIFF
--- a/app/views/palettes/index.html.erb
+++ b/app/views/palettes/index.html.erb
@@ -1,10 +1,12 @@
 <h1>Palettes</h1>
 
 <%= link_to 'New Palette', '/palettes/new' %>
-
+<br>
+<br>
 <% @palettes.each do |palette| %>
 
   <h3><%= palette.name %></h3>
+  <%= link_to "Edit", "/palettes/#{palette.id}/edit"%>
   <p>Created At: <%= palette.created_at%></p>
-
+  <br>
 <% end %>

--- a/spec/features/palettes/index_spec.rb
+++ b/spec/features/palettes/index_spec.rb
@@ -40,4 +40,13 @@ RSpec.describe 'Palettes index page' do
       expect(current_path).to eq("/paints")
     end
   end
+
+  describe 'User Story 17' do
+    it 'displays an edit link next to each Palette' do
+      visit "/palettes"
+      first(:link, "Edit").click
+      # palette_2 comes before palette on page in test data
+      expect(current_path).to eq("/palettes/#{palette_2.id}/edit")
+    end
+  end
 end


### PR DESCRIPTION
User Story 17, Parent Update From Parent Index Page 

As a visitor
When I visit the parent index page
Next to every parent, I see a link to edit that parent's info
When I click the link
I should be taken to that parent's edit page where I can update its information just like in User Story 12
