### PR TITLE
Add User Story 18

### DIFF
--- a/app/views/paints/index.html.erb
+++ b/app/views/paints/index.html.erb
@@ -2,6 +2,7 @@
 
 <% @paints.each do |paint| %>
   <h3>Paint Name: <%= paint.paint_name %></h3>
+  <%= link_to "Edit", "/paints/#{paint.id}/edit" %>
   <p>Medium: <%= paint.medium%></p>
   <p>Series: <%= paint.series%></p>
   <p>Opaque: <%= paint.opaque%></p>

--- a/app/views/palettes/index.html.erb
+++ b/app/views/palettes/index.html.erb
@@ -6,7 +6,7 @@
 <% @palettes.each do |palette| %>
 
   <h3><%= palette.name %></h3>
-  <%= link_to "Edit", "/palettes/#{palette.id}/edit"%>
+  <%= link_to "Edit", "/palettes/#{palette.id}/edit" %>
   <p>Created At: <%= palette.created_at%></p>
   <br>
 <% end %>

--- a/spec/features/paints/index_spec.rb
+++ b/spec/features/paints/index_spec.rb
@@ -59,4 +59,15 @@ RSpec.describe 'Paints index page' do
       expect(page).to_not have_content(paint_4.opaque)
     end
   end
+
+  describe 'User Story 18' do
+    it 'Next to each paint, there is an edit link that takes you to paint edit page' do
+      visit "/paints"
+
+      expect(page).to have_link("Edit")
+
+      first(:link, "Edit").click
+      expect(current_path).to eq("/paints/#{paint.id}/edit")
+    end
+  end
 end

--- a/spec/features/palettes/index_spec.rb
+++ b/spec/features/palettes/index_spec.rb
@@ -44,6 +44,9 @@ RSpec.describe 'Palettes index page' do
   describe 'User Story 17' do
     it 'displays an edit link next to each Palette' do
       visit "/palettes"
+
+      expect(page).to have_link("Edit")
+
       first(:link, "Edit").click
       # palette_2 comes before palette on page in test data
       expect(current_path).to eq("/palettes/#{palette_2.id}/edit")


### PR DESCRIPTION
User Story 18, Child Update From Childs Index Page 

As a visitor
When I visit the `child_table_name` index page or a parent `child_table_name` index page
Next to every child, I see a link to edit that child's info
When I click the link
I should be taken to that `child_table_name` edit page where I can update its information just like in User Story 14