### PR TITLE
Add User Story 19

### DIFF
--- a/app/controllers/palettes_controller.rb
+++ b/app/controllers/palettes_controller.rb
@@ -27,6 +27,13 @@ class PalettesController < ApplicationController
     redirect_to "/palettes/#{palette.id}"
   end
 
+  def destroy
+    palette = Palette.find(params[:id])
+    palette.paints.destroy_all
+    palette.destroy
+    redirect_to '/palettes'
+  end
+
   private
 
   def palette_params

--- a/app/views/palettes/show.html.erb
+++ b/app/views/palettes/show.html.erb
@@ -7,4 +7,6 @@
 <p>Recyclable? <%= @palette.recyclable %></p>
 <br>
 <%= link_to "Update Palette", "/palettes/#{@palette.id}/edit"%>
-
+<br>
+<%= link_to "Delete Palette", "/palettes/#{@palette.id}", method: :delete, data:
+  { confirm: "Delete #{@palette.name}?" } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,4 +19,6 @@ Rails.application.routes.draw do
 
   get '/paints/:id/edit', to: 'paints#edit'
   patch '/paints/:id', to: 'paints#update'
+
+  delete "/palettes/:id", to: 'palettes#destroy'
 end

--- a/spec/features/palettes/show_spec.rb
+++ b/spec/features/palettes/show_spec.rb
@@ -47,4 +47,25 @@ RSpec.describe 'Palettes show page' do
       expect(current_path).to eq("/palettes/#{palette.id}/paints")
     end
   end
+
+  describe 'User Story 12' do
+    it 'displays Update Palette link, links to edit page' do
+      visit "/palettes/#{palette.id}"
+
+      click_on "Update Palette"
+
+      expect(current_path).to eq("/palettes/#{palette.id}/edit")
+    end
+  end
+
+  describe 'User Story 19' do
+    it 'displays Delete Palette link, removes the palette from the page' do
+      visit "/palettes/#{palette.id}"
+
+      click_on "Delete Palette"
+
+      expect(current_path).to eq("/palettes")
+      expect(page).to_not have_content(palette.name)
+    end
+  end
 end


### PR DESCRIPTION
User Story 19, Parent Delete 

As a visitor
When I visit a parent show page
Then I see a link to delete the parent
When I click the link "Delete Parent"
Then a 'DELETE' request is sent to '/parents/:id',
the parent is deleted, and all child records are deleted
and I am redirected to the parent index page where I no longer see this parent