### PR TITLE
Add User Story 20

### DIFF
--- a/app/controllers/paints_controller.rb
+++ b/app/controllers/paints_controller.rb
@@ -18,6 +18,12 @@ class PaintsController < ApplicationController
     redirect_to "/paints/#{paint.id}"
   end
 
+  def destroy
+    paint = Paint.find(params[:id])
+    paint.destroy
+    redirect_to "/paints"
+  end
+
   private
 
   def paint_params

--- a/app/views/paints/show.html.erb
+++ b/app/views/paints/show.html.erb
@@ -6,3 +6,6 @@
 <p>Palette ID: <%= @paint.palette_id %></p>
 
 <%= link_to "Update Paint", "/paints/#{@paint.id}/edit"%>
+<br>
+<%= link_to "Delete Paint", "/paints/#{@paint.id}", method: :delete, data:
+  { confirm: "Delete #{@paint.paint_name}?" } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,4 +21,6 @@ Rails.application.routes.draw do
   patch '/paints/:id', to: 'paints#update'
 
   delete "/palettes/:id", to: 'palettes#destroy'
+  delete "/paints/:id", to: 'paints#destroy'
+
 end

--- a/spec/features/paints/show_spec.rb
+++ b/spec/features/paints/show_spec.rb
@@ -51,4 +51,15 @@ RSpec.describe 'Paints show page' do
       expect(current_path).to eq("/paints/#{paint.id}/edit")
     end
   end
+
+  describe 'User Story 20' do
+    it 'displays Delete Paint link, removes the paint from the page' do
+      visit "/paints/#{paint.id}"
+
+      click_on "Delete Paint"
+
+      expect(current_path).to eq("/paints")
+      expect(page).to_not have_content(paint.paint_name)
+    end
+  end
 end


### PR DESCRIPTION
User Story 20, Child Delete 

As a visitor
When I visit a child show page
Then I see a link to delete the child "Delete Child"
When I click the link
Then a 'DELETE' request is sent to '/child_table_name/:id',
the child is deleted,
and I am redirected to the child index page where I no longer see this child