### PR TITLE
Add User Story 21

### DIFF
--- a/app/controllers/palette_paints_controller.rb
+++ b/app/controllers/palette_paints_controller.rb
@@ -3,6 +3,8 @@ class PalettePaintsController < ApplicationController
     @palette = Palette.find(params[:id])
     if params[:sort] == "alphabetical"
       @paints = @palette.paints.sort_alpha
+    elsif params[:series]
+      @paints = @palette.paints.series_filter(params[:series])
     else
       @paints = @palette.paints
     end

--- a/app/models/paint.rb
+++ b/app/models/paint.rb
@@ -8,4 +8,8 @@ class Paint < ApplicationRecord
   def self.sort_alpha
     order(:paint_name)
   end
+
+  def self.series_filter(num)
+    where("series > #{num}")
+  end
 end

--- a/app/views/palette_paints/index.html.erb
+++ b/app/views/palette_paints/index.html.erb
@@ -2,6 +2,15 @@
 
 <%= link_to 'Create Paint', "/palettes/#{@palette.id}/paints/new" %>
 <%= link_to 'Sort Paint A-Z', sort: "alphabetical" %>
+<br>
+<br>
+<div id="paint-series-select">
+<%= form_with url: "/palettes/#{@palette.id}/paints", method: :get, local: true do |form| %>
+    <%# <%= form.label :series, "Series Filter: " %>
+    Only show paints with Series number greater than: <%= form.number_field :series %>
+    <%= form.submit 'Submit' %></p>
+<% end %>
+
 
 <% @paints.each do |paint| %>
   <h3>Paint Name: <%= paint.paint_name %></h3>

--- a/spec/features/palette_paints/index_spec.rb
+++ b/spec/features/palette_paints/index_spec.rb
@@ -52,4 +52,30 @@ RSpec.describe 'Palette Paints index page' do
       expect(paint_6.paint_name).to appear_before(paint_3.paint_name)
     end
   end
+
+  describe 'User Story 21' do
+    it 'I see a form that allows me to input a number value' do
+      visit "/palettes/#{palette.id}/paints"
+      within("div#paint-series-select") do 
+        expect(page).to have_field('series')
+        expect(page).to have_button('Submit')
+      end
+    end
+
+    describe 'I input a number value, click the submit, and am redirected back to palette_paints index ' do
+      it 'See only the records that meet that threshold shown' do
+        visit "/palettes/#{palette.id}/paints"
+        
+        fill_in :series, with: 1
+        # save_and_open_page
+        click_button "Submit"
+
+        expect(current_path).to eq("/palettes/#{palette.id}/paints")
+        expect(page).to have_content(paint_2.paint_name)
+        expect(page).to_not have_content(paint.paint_name)
+        expect(page).to_not have_content(paint_3.paint_name)
+        expect(page).to_not have_content(paint_6.paint_name)
+      end
+    end
+  end
 end

--- a/spec/models/paint_spec.rb
+++ b/spec/models/paint_spec.rb
@@ -29,5 +29,13 @@ RSpec.describe Paint do
         end
       end
     end
+
+    describe 'User Story 21' do
+      describe '::series_filter' do
+        it 'Only returns records with more than `number` of `column_name`' do
+          expect(Paint.series_filter(2)).to eq([paint_2, paint_4])
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
User Story 21, Display Records Over a Given Threshold 

As a visitor
When I visit the Parent's children Index Page
I see a form that allows me to input a number value
When I input a number value and click the submit button for 'Only return records with more than `number` of `column_name`'
Then I am brought back to the current index page with only the records that meet that threshold shown.