### PR TITLE
Add User Story 22

### DIFF
--- a/app/views/palettes/index.html.erb
+++ b/app/views/palettes/index.html.erb
@@ -7,6 +7,9 @@
 
   <h3><%= palette.name %></h3>
   <%= link_to "Edit", "/palettes/#{palette.id}/edit" %>
+  <br>
+  <%= link_to "Delete", "/palettes/#{palette.id}", method: :delete, data:
+  { confirm: "Delete #{palette.name}?" } %>
   <p>Created At: <%= palette.created_at%></p>
   <br>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,5 +22,6 @@ Rails.application.routes.draw do
 
   delete "/palettes/:id", to: 'palettes#destroy'
   delete "/paints/:id", to: 'paints#destroy'
+  delete "/palettes", to: 'palettes#destroy'
 
 end

--- a/spec/features/palettes/index_spec.rb
+++ b/spec/features/palettes/index_spec.rb
@@ -52,4 +52,15 @@ RSpec.describe 'Palettes index page' do
       expect(current_path).to eq("/palettes/#{palette_2.id}/edit")
     end
   end
+
+  describe 'User Story 22' do
+    it 'displays Delete Palette link, removes the palette from the page' do
+      visit "/palettes"
+
+      first(:link, "Delete").click
+
+      expect(current_path).to eq("/palettes")
+      expect(page).to_not have_content(palette_2.name)
+    end
+  end
 end


### PR DESCRIPTION
User Story 22, Parent Delete From Parent Index Page 

As a visitor
When I visit the parent index page
Next to every parent, I see a link to delete that parent
When I click the link
I am returned to the Parent Index Page where I no longer see that parent