### PR TITLE
Add User Story 23

### DIFF
--- a/app/views/paints/index.html.erb
+++ b/app/views/paints/index.html.erb
@@ -3,8 +3,12 @@
 <% @paints.each do |paint| %>
   <h3>Paint Name: <%= paint.paint_name %></h3>
   <%= link_to "Edit", "/paints/#{paint.id}/edit" %>
+  <br>
+  <%= link_to "Delete", "/paints/#{paint.id}", method: :delete, data:
+  { confirm: "Delete #{paint.paint_name}?" } %>
   <p>Medium: <%= paint.medium%></p>
   <p>Series: <%= paint.series%></p>
   <p>Opaque: <%= paint.opaque%></p>
   <p>Palette ID: <%= paint.palette_id%></p>
+  <br>
 <% end %>

--- a/app/views/palette_paints/index.html.erb
+++ b/app/views/palette_paints/index.html.erb
@@ -18,4 +18,6 @@
   <p>Series: <%= paint.series%></p>
   <p>Opaque: <%= paint.opaque%></p>
   <p>Palette ID: <%= paint.palette_id%></p>
+  <%= link_to "Delete", "/paints/#{paint.id}", method: :delete, data:
+  { confirm: "Delete #{paint.paint_name}?" } %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,5 +23,5 @@ Rails.application.routes.draw do
   delete "/palettes/:id", to: 'palettes#destroy'
   delete "/paints/:id", to: 'paints#destroy'
   delete "/palettes", to: 'palettes#destroy'
-
+  # delete "/palettes/:id/paints", to: 'palette_paints#destroy'
 end

--- a/spec/features/paints/index_spec.rb
+++ b/spec/features/paints/index_spec.rb
@@ -70,4 +70,15 @@ RSpec.describe 'Paints index page' do
       expect(current_path).to eq("/paints/#{paint.id}/edit")
     end
   end
+
+  describe 'User Story 23' do
+    it 'displays Delete Paint link, removes the paint from the paints index page' do
+      visit "/paints"
+
+      first(:link, "Delete").click
+
+      expect(current_path).to eq("/paints")
+      expect(page).to_not have_content(paint.paint_name)
+    end
+  end
 end

--- a/spec/features/palette_paints/index_spec.rb
+++ b/spec/features/palette_paints/index_spec.rb
@@ -78,4 +78,15 @@ RSpec.describe 'Palette Paints index page' do
       end
     end
   end
+
+  describe 'User Story 23' do
+    it 'displays Delete Paint link, removes the paint from the palette_paints index page' do
+      visit "/palettes/#{palette.id}/paints"
+
+      first(:link, "Delete").click
+
+      expect(current_path).to eq("/paints")
+      expect(page).to_not have_content(paint.paint_name)
+    end
+  end
 end


### PR DESCRIPTION
User Story 23, Child Delete From Childs Index Page 

As a visitor
When I visit the `child_table_name` index page or a parent `child_table_name` index page
Next to every child, I see a link to delete that child
When I click the link
I should be taken to the `child_table_name` index page where I no longer see that child