### PR TITLE
Add Palette and Paint name links to show pages

### DIFF
--- a/app/views/paints/index.html.erb
+++ b/app/views/paints/index.html.erb
@@ -1,7 +1,7 @@
 <h1>Paints</h2>
 
 <% @paints.each do |paint| %>
-  <h3>Paint Name: <%= paint.paint_name %></h3>
+  <h3><%= link_to "#{paint.paint_name}", "/paints/#{paint.id}" %></h3>
   <%= link_to "Edit", "/paints/#{paint.id}/edit" %>
   <br>
   <%= link_to "Delete", "/paints/#{paint.id}", method: :delete, data:

--- a/app/views/palette_paints/index.html.erb
+++ b/app/views/palette_paints/index.html.erb
@@ -13,7 +13,7 @@
 
 
 <% @paints.each do |paint| %>
-  <h3>Paint Name: <%= paint.paint_name %></h3>
+  <h3><%= link_to "#{paint.paint_name}", "/paints/#{paint.id}" %></h3>
   <p>Medium: <%= paint.medium%></p>
   <p>Series: <%= paint.series%></p>
   <p>Opaque: <%= paint.opaque%></p>

--- a/app/views/palettes/index.html.erb
+++ b/app/views/palettes/index.html.erb
@@ -5,7 +5,7 @@
 <br>
 <% @palettes.each do |palette| %>
 
-  <h3><%= palette.name %></h3>
+  <h3><%= link_to "#{palette.name}", "/palettes/#{palette.id}" %></h3>
   <%= link_to "Edit", "/palettes/#{palette.id}/edit" %>
   <br>
   <%= link_to "Delete", "/palettes/#{palette.id}", method: :delete, data:

--- a/spec/features/paints/index_spec.rb
+++ b/spec/features/paints/index_spec.rb
@@ -81,4 +81,16 @@ RSpec.describe 'Paints index page' do
       expect(page).to_not have_content(paint.paint_name)
     end
   end
+
+  describe 'index paint name display links' do
+    it 'name of paint links to that paint`s show page' do
+      visit "/paints"
+
+      expect(page).to have_link("#{paint.paint_name}")
+
+      click_link "#{paint.paint_name}"
+
+      expect(current_path).to eq("/paints/#{paint.id}")
+    end
+  end
 end

--- a/spec/features/palette_paints/index_spec.rb
+++ b/spec/features/palette_paints/index_spec.rb
@@ -89,4 +89,16 @@ RSpec.describe 'Palette Paints index page' do
       expect(page).to_not have_content(paint.paint_name)
     end
   end
+
+  describe 'palette_paint name display links' do
+    it 'name of palette paint links to that paint`s show page' do
+      visit "/palettes/#{palette.id}/paints"
+
+      expect(page).to have_link("#{paint.paint_name}")
+
+      click_link "#{paint.paint_name}"
+
+      expect(current_path).to eq("/paints/#{paint.id}")
+    end
+  end
 end

--- a/spec/features/palettes/index_spec.rb
+++ b/spec/features/palettes/index_spec.rb
@@ -63,4 +63,16 @@ RSpec.describe 'Palettes index page' do
       expect(page).to_not have_content(palette_2.name)
     end
   end
+
+  describe 'index palette name display links' do
+    it 'name of palette links to that palette`s show page' do
+      visit "/palettes"
+
+      expect(page).to have_link("#{palette_2.name}")
+
+      click_link "#{palette_2.name}"
+
+      expect(current_path).to eq("/palettes/#{palette_2.id}")
+    end
+  end
 end


### PR DESCRIPTION
On palette index, paint index, and palette_paints index, all names link to their show pages